### PR TITLE
[roles:sft-server] Change data type of how unsupported client versions are defined

### DIFF
--- a/roles/sft-server/defaults/main.yml
+++ b/roles/sft-server/defaults/main.yml
@@ -1,7 +1,7 @@
-# NOTE: variables set here can be overridden when invoking the role
+# NOTE: variables set here can - and potentially should - be overridden when invoking the role
 
 
-# INFO: The following variables are mandatory will and will be tested for existence
+# INFO: The following variables are MANDATORY and will be tested for existence
 
 # There are three different ways to define which version is going to be installed.
 # All of them are mutual exclusive.
@@ -49,6 +49,14 @@ sft_public_ip: >-
         )
         | first
     }}
+
+# NOTE: exclude certain versions from being supported by the SFT server.
+#       The variable defines a list of versions, where one or more version strings may
+#       be prefixed by a '<' modifier. This means that all versions lower than that, are
+#       rejected by the server.
+sft_unsupported_client_versions: []     # each client version is supported
+#  - '<5.2.10'
+#  - '6.1.3'
 
 metrics_enabled: false
 

--- a/roles/sft-server/templates/sftd.service.j2
+++ b/roles/sft-server/templates/sftd.service.j2
@@ -23,8 +23,8 @@ ExecStart={{ sftd_bin_path }} \
             -A '{{ sft_public_ip }}' \
             -M '{{ sftd_incoming_ip }}' \
             -r '{{ sftd_metrics_port }}' \
-            {% if sft_allowed_client_versions is defined -%}
-            -b "{{ sft_allowed_client_versions }}" \
+            {% if sft_unsupported_client_versions | length > 0 -%}
+            -b '{{ sft_unsupported_client_versions | map('trim') | join(',') }}' \
             {% endif -%}
             -u 'https://{{ sft_fqdn }}'
 

--- a/roles/sft-server/templates/sftd.service.j2
+++ b/roles/sft-server/templates/sftd.service.j2
@@ -9,9 +9,10 @@ Wants=network-online.target
 TimeoutStartSec=0
 Restart=always
 
-# maximum size of core files (bytes)
-LimitCORE=infinity
-LimitCORESoft=0
+# NOTE: maximum size of core files (bytes); inherently limited
+#       by overall amount of available memory
+# SYNTAX: $soft:$hard
+LimitCORE=0:infinity
 
 LimitNOFILE={{ sftd_limit_nofile }}
 

--- a/roles/sft-server/vars/main.yml
+++ b/roles/sft-server/vars/main.yml
@@ -1,4 +1,4 @@
-# NOTE: considered to be constants due to high precedence
+# NOTE: variables set here are considered to be CONSTANTS due to high precedence
 
 sft_artifact_target_path: '/tmp/sft-artifact.tar.gz'
 
@@ -11,12 +11,6 @@ sftd_incoming_ip: '127.0.0.1'
 
 # TODO: adjust calculation when/if an actual port range is defined. Also, see task 'allowing sft media ingress'
 sftd_limit_nofile: "{{ 65536 - 1024 }}"
-
-# NOTE: we can limit the client versions allowed by the SFT. The format of this string
-#       is a comma separated list of version numbers (no spaces allowed), potentially
-#       prefixed by a '<' modifier, meaning that all versions earlier than that
-#       are rejected by the server.
-# sft_allowed_client_versions: '<5.2.10,5.2.15'
 
 nginx_conf_dir: '/etc/nginx/conf.d'
 nginx_dhparams_path: '/etc/ssl/nginx-dhparams.pem'


### PR DESCRIPTION
This is basically a re-do of the initial feature that started to allow
excluding support for specific client versions.

* renamed variable and set a default; the name implied a including semantic, whereas
  in reality it has an excluding semantic
* change from string to list of strings to programmatically enforce the syntax
  requirements: comma-separated, no empty space. It doesn't validate the format of
  an item, since the consumer (sftd) should take care of that *fingers crossed*
* moved variable to defaults since it can be overridden from outside of the role

Remove 'LimitCORESoft' from sftd unit file: The name of the value is not supported,
instead the proper syntax is `soft:hard` or setting both to the same value by defined
a single value