### PR TITLE
[roles:sft-server] Relocate task that configures sftd unit file

### DIFF
--- a/roles/sft-server/tasks/configure.yml
+++ b/roles/sft-server/tasks/configure.yml
@@ -1,3 +1,13 @@
+- name: copying systemd service unit
+  template:
+    src: 'sftd.service.j2'
+    dest: "/etc/systemd/system/{{ service_name }}.service"
+    owner: root
+    group: root
+    mode: '644'
+  register: unit_sftd
+
+
 - name: creating directory for coredump configuation
   file:
     state: directory

--- a/roles/sft-server/tasks/install.yml
+++ b/roles/sft-server/tasks/install.yml
@@ -48,15 +48,6 @@
     state: 'file'
     mode: '755'
 
-- name: copying systemd service unit
-  template:
-    src: 'sftd.service.j2'
-    dest: "/etc/systemd/system/{{ service_name }}.service"
-    owner: root
-    group: root
-    mode: '644'
-  register: unit_sftd
-
 
 - name: installing core-dump components
   apt:

--- a/roles/sft-server/tasks/start.yml
+++ b/roles/sft-server/tasks/start.yml
@@ -2,5 +2,5 @@
   systemd:
     name: "{{ service_name }}"
     enabled: yes
-    state: "{{ 'restarted' if binary_sftd.changed else 'started' }}"
-    daemon_reload: "{{ 'yes' if unit_sftd.changed else 'no' }}"
+    state: "{{ 'restarted' if binary_sftd is defined and binary_sftd.changed else 'started' }}"
+    daemon_reload: "{{ 'yes' if unit_sftd is defined and unit_sftd.changed else 'no' }}"


### PR DESCRIPTION
Relocating the code that manages unit file for sftd in conjunction with
testing for undefined variables allows to only partially invoke the role,
e.g. to re-deploy a new sftd artifact. In other words, now it's possible
to do
```
tasks:
  - import_role:
      name: 'sft-server'
      tasks_from: 'install'
  - import_role:
      name: 'sft-server'
      tasks_from: 'start'
  - import_role:
      name: 'sft-server'
      tasks_from: 'test'
```
 And it allows to omit variables that  are not actually referred to in certain
 task files a/o enforced by 'assert.yml'