### PR TITLE
[roles:sft-server] Disable log rate limit for sftd

### DIFF
--- a/roles/sft-server/templates/sftd.service.j2
+++ b/roles/sft-server/templates/sftd.service.j2
@@ -16,6 +16,13 @@ LimitCORE=0:infinity
 
 LimitNOFILE={{ sftd_limit_nofile }}
 
+# NOTE: disable limit rate for logs to prevent journald from suppressing
+#       when throughput increases. It requires both to be overridden,
+#       otherwise journald would stop handling logs after the attempt
+#       to suppress for the fist time after service start
+LogRateLimitIntervalSec=0
+LogRateLimitBurst=0
+
 DynamicUser=yes
 
 ExecStart={{ sftd_bin_path }} \


### PR DESCRIPTION
Journald's log rate limit is enabled by default. But since sftd has
a rather high output, sometimes logs get lost ("suppressed"), which would have
been helpful in certain cases.

When log aggregation has been added to the mix, it might even be
reasonable to to have a dedicated journald process accommodating
sftd, because of its output rate.

docs: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#LogRateLimitIntervalSec=