### PR TITLE
[roles:sft-server] Explicitly define firewall rules for UDP

### DIFF
--- a/roles/sft-server/tasks/main.yml
+++ b/roles/sft-server/tasks/main.yml
@@ -11,7 +11,7 @@
   import_tasks: start.yml
 
 - name: exposing service
-  import_tasks: ingress.yml
+  import_tasks: traffic.yml
 
 - name: testing service
   import_tasks: test.yml

--- a/roles/sft-server/tasks/traffic.yml
+++ b/roles/sft-server/tasks/traffic.yml
@@ -26,21 +26,26 @@
   ufw:
     rule: allow
     proto: tcp
-    to_port: "{{ item }}"
+    direction: in
+    to_port: '22'
     state: reloaded
-  loop:
-    - '22'
 
-# NOTE: not yet enabled because stfd still doesn't support defining a port range, but will be soon
-#
-#- name: allowing sft media ingress
-#  ufw:
-#    rule: allow
-#    proto: udp
-#    to_port: "{{ item }}"
-#    state: reloaded
-#  loop:
-#    - '1048:65535'
+
+- name: allowing SFT media ingress
+  ufw:
+    rule: allow
+    proto: udp
+    direction: in
+    to_port: "{{ sftd_udp_port_range_start }}:{{ sftd_udp_port_range_end }}"
+    state: reloaded
+
+- name: allowing SFT media egress
+  ufw:
+    rule: allow
+    proto: udp
+    direction: out
+    from_port: "{{ sftd_udp_port_range_start }}:{{ sftd_udp_port_range_end }}"
+    state: reloaded
 
 
 - name: configuring SFT nginx vhost

--- a/roles/sft-server/vars/main.yml
+++ b/roles/sft-server/vars/main.yml
@@ -7,6 +7,10 @@ sftd_bin_path: '/usr/local/bin/sftd'
 sftd_signaling_port: 1030
 sftd_metrics_port: 1040
 
+# NOTE: use the complete range of non-privileged ports
+sftd_udp_port_range_start: 1024
+sftd_udp_port_range_end: 65535
+
 sftd_incoming_ip: '127.0.0.1'
 
 # TODO: adjust calculation when/if an actual port range is defined. Also, see task 'allowing sft media ingress'


### PR DESCRIPTION
This changes allows ingress and egress UDP media traffic. Renaming the file seemed
appropriate given the content is not ingress anymore. I might have lost track of
this one along the  way during initial development.
In the future, the defined port range can be made configurable form the outside,
but for now this doesn't seem necessary. Furthermore, sftd should adhere this range
by exposing this configuration option.