### PR TITLE
[roles:srv-announcer] Add basic role structure and tasks to install executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,18 @@ SFT - Selective Forwarding TURN
 
 ### About this repository
 
-THe structure of this repository structured towards a new Ansible feature called `collection`. However, the content
-only supports Ansible __2.7__ (for now). To already allow structural elements like `./roles`, some
-[workarounds](https://github.com/ansible/ansible/issues/16804) have been applied.
+THe layout of this repository is structured with a new Ansible feature in mind that is called `collection`. However, the
+content only supports Ansible __2.7__ (for now). To already allow structural elements like `./roles`, some
+[workarounds](https://github.com/ansible/ansible/issues/16804) have been applied, namely an almost empty `meta/main.yml`.
+
 When we will start to support 2.9, the main TODO is to fully adapt the official structure mentioned in the docs:
 
 * [usage](https://docs.ansible.com/ansible/2.9/user_guide/collections_using.html)
 * [development](https://docs.ansible.com/ansible/2.9/dev_guide/developing_collections.html)
+
+Until then, to use one or more roles from this repository installed with `ansible-galaxy`, the proposed workaround is
+to extend `roles_path` with a *"deep link"* pointing to the location where it was downloaded to, e.g. 
+`$GALAXY_INSTALL_PATH/ansible-sft/roles`.
 
 
 ### Development setup

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,5 @@
+# NOTE: dummy file to make ansible-galaxy put the whole content under ROLES_PATH/$name,
+#       even though this is currently not a Ansible collection
+
+galaxy_info: {}
+dependencies: []

--- a/roles/srv-announcer/defaults/main.yml
+++ b/roles/srv-announcer/defaults/main.yml
@@ -15,5 +15,37 @@
 # announce_artifact_file_url: URL
 # announce_artifact_checksum: value
 
+# DOCS: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+# announcer_aws_key_id: String
+# announcer_aws_access_key: String
+# announcer_aws_region: String
+
+# announcer_zone_domain: String, e.g. domain.tld
+
+# NOTE: The srv-announcer can only manage one entry in the SRV record list, but the role allows
+#       to define multiple entries. For each entry a new systemd unit is created. To also
+#       facilitate the usecase of removing a certain unit file, each block allows to define the
+#       attribute `deprecated` in order to indicate a unit removal. After running a play with
+#       that attribute, the whole block can be safely removed
+# EXAMPLE:
+# ```yaml
+#  mx:
+#    name: _mx._tcp.sub.
+#    target: mx1.sub.domain.tld
+#  metrics:
+#    name: _metrics._tcp.sub.
+#    target: monitoring.sub.domain.tld
+#    deprecated: true
+# ```
+announcer_srv_records: {}
+
 
 # INFO: The following variables are NOT mandatory and won't be tested for existence
+
+# NOTE: in seconds
+announcer_record_ttl: 60
+# NOTE: relative values
+announcer_record_priority: 10
+announcer_record_weight: 10
+
+announcer_record_port: 443

--- a/roles/srv-announcer/defaults/main.yml
+++ b/roles/srv-announcer/defaults/main.yml
@@ -6,21 +6,21 @@
 # There are three different ways to define which version is going to be installed.
 # All of them are mutual exclusive.
 # 1.
-# announce_artifact_file_path: local path in filesystem
+# srv_announcer_artifact_file_path: local path in filesystem
 #
 # 2.
-# announcer_version: string of a specific release version
+# srv_announcer_version: string of a specific release version
 #
 # 3.
-# announce_artifact_file_url: URL
-# announce_artifact_checksum: value
+# srv_announcer_artifact_file_url: URL
+# srv_announcer_artifact_checksum: value
 
 # DOCS: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-# announcer_aws_key_id: String
-# announcer_aws_access_key: String
-# announcer_aws_region: String
+# srv_announcer_aws_key_id: String
+# srv_announcer_aws_access_key: String
+# srv_announcer_aws_region: String
 
-# announcer_zone_domain: String, e.g. domain.tld
+# srv_announcer_zone_domain: String, e.g. domain.tld
 
 # NOTE: The srv-announcer can only manage one entry in the SRV record list, but the role allows
 #       to define multiple entries. For each entry a new systemd unit is created. To also
@@ -37,15 +37,15 @@
 #    target: monitoring.sub.domain.tld
 #    deprecated: true
 # ```
-announcer_srv_records: {}
+srv_announcer_srv_records: {}
 
 
 # INFO: The following variables are NOT mandatory and won't be tested for existence
 
 # NOTE: in seconds
-announcer_record_ttl: 60
+srv_announcer_record_ttl: 60
 # NOTE: relative values
-announcer_record_priority: 10
-announcer_record_weight: 10
+srv_announcer_record_priority: 10
+srv_announcer_record_weight: 10
 
-announcer_record_port: 443
+srv_announcer_record_port: 443

--- a/roles/srv-announcer/defaults/main.yml
+++ b/roles/srv-announcer/defaults/main.yml
@@ -22,22 +22,12 @@
 
 # srv_announcer_zone_domain: String, e.g. domain.tld
 
-# NOTE: The srv-announcer can only manage one entry in the SRV record list, but the role allows
-#       to define multiple entries. For each entry a new systemd unit is created. To also
-#       facilitate the usecase of removing a certain unit file, each block allows to define the
-#       attribute `deprecated` in order to indicate a unit removal. After running a play with
-#       that attribute, the whole block can be safely removed
-# EXAMPLE:
-# ```yaml
-#  mx:
-#    name: _mx._tcp.sub.
-#    target: mx1.sub.domain.tld
-#  metrics:
-#    name: _metrics._tcp.sub.
-#    target: monitoring.sub.domain.tld
-#    deprecated: true
-# ```
-srv_announcer_srv_records: {}
+# NOTE: One srv-announcer instance can only manage one entry in the SRV record list.
+#       In order to remove the target from the record's list, one must stop the service it is
+#       announcing so that the health check that is performed by the srv-announcer recognizes
+#       its unavailability and removes the target from the list
+# srv_announcer_record_name: String
+# srv_announcer_record_target: String
 
 
 # INFO: The following variables are NOT mandatory and won't be tested for existence

--- a/roles/srv-announcer/defaults/main.yml
+++ b/roles/srv-announcer/defaults/main.yml
@@ -1,0 +1,19 @@
+# NOTE: variables set here can - and potentially should - be overridden when invoking the role
+
+
+# INFO: The following variables are MANDATORY or will be tested for existence
+
+# There are three different ways to define which version is going to be installed.
+# All of them are mutual exclusive.
+# 1.
+# announce_artifact_file_path: local path in filesystem
+#
+# 2.
+# announcer_version: string of a specific release version
+#
+# 3.
+# announce_artifact_file_url: URL
+# announce_artifact_checksum: value
+
+
+# INFO: The following variables are NOT mandatory and won't be tested for existence

--- a/roles/srv-announcer/meta/main.yml
+++ b/roles/srv-announcer/meta/main.yml
@@ -1,0 +1,20 @@
+galaxy_info:
+  role_name: srv-announcer
+  author: wireapp
+  description: Process to announce a server via SRV DNS record
+  company: Wire Swiss GmbH
+  license: AGPL
+
+  min_ansible_version: 2.7
+  github_branch: master
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - 18.04
+
+  galaxy_tags:
+    - SRV
+    - DNS
+
+dependencies: []

--- a/roles/srv-announcer/tasks/assert.yml
+++ b/roles/srv-announcer/tasks/assert.yml
@@ -1,13 +1,13 @@
 - name: verifying if all required variables for the srv-announcer are set
   assert:
     that:
-      - announcer_zone_domain is defined
-    msg: '[ERR] Variable not set: announcer_zone_domain'
+      - srv_announcer_zone_domain is defined
+    msg: '[ERR] Variable not set: srv_announcer_zone_domain'
 
 - name: verifying if all required variables for the AWS client are set
   assert:
     that:
-      - announcer_aws_key_id is defined
-      - announcer_aws_access_key is defined
-      - announcer_aws_region is defined
-    msg: '[ERR] Variable not set: announcer_aws_*'
+      - srv_announcer_aws_key_id is defined
+      - srv_announcer_aws_access_key is defined
+      - srv_announcer_aws_region is defined
+    msg: '[ERR] Variable not set: srv_announcer_aws_*'

--- a/roles/srv-announcer/tasks/assert.yml
+++ b/roles/srv-announcer/tasks/assert.yml
@@ -1,5 +1,13 @@
-- name: verifying if all required variables for SFT are set
+- name: verifying if all required variables for the srv-announcer are set
   assert:
     that:
-      - sft_fqdn is defined
-    msg: '[ERR] Variable not set: sft_fqdn'
+      - announcer_zone_domain is defined
+    msg: '[ERR] Variable not set: announcer_zone_domain'
+
+- name: verifying if all required variables for the AWS client are set
+  assert:
+    that:
+      - announcer_aws_key_id is defined
+      - announcer_aws_access_key is defined
+      - announcer_aws_region is defined
+    msg: '[ERR] Variable not set: announcer_aws_*'

--- a/roles/srv-announcer/tasks/assert.yml
+++ b/roles/srv-announcer/tasks/assert.yml
@@ -1,0 +1,5 @@
+- name: verifying if all required variables for SFT are set
+  assert:
+    that:
+      - sft_fqdn is defined
+    msg: '[ERR] Variable not set: sft_fqdn'

--- a/roles/srv-announcer/tasks/assert.yml
+++ b/roles/srv-announcer/tasks/assert.yml
@@ -2,7 +2,13 @@
   assert:
     that:
       - srv_announcer_zone_domain is defined
-    msg: '[ERR] Variable not set: srv_announcer_zone_domain'
+      - srv_announcer_record_name is defined
+      - srv_announcer_record_target is defined
+    msg: |
+      [ERR] Variable not set:
+        srv_announcer_zone_domain,
+        srv_announcer_record_name,
+        srv_announcer_record_target
 
 - name: verifying if all required variables for the AWS client are set
   assert:

--- a/roles/srv-announcer/tasks/configure.yml
+++ b/roles/srv-announcer/tasks/configure.yml
@@ -23,3 +23,12 @@
     group: root
     mode: '644'
   register: unit_srva
+
+- name: copying systemd slice unit to manage SRV annoucer resources
+  template:
+    src: 'discovery.slice.j2'
+    dest: "/etc/systemd/system/discovery.slice"
+    owner: root
+    group: root
+    mode: '644'
+  register: slice_srva

--- a/roles/srv-announcer/tasks/configure.yml
+++ b/roles/srv-announcer/tasks/configure.yml
@@ -1,3 +1,20 @@
+- name: creating srv-announcer configuration path
+  file:
+    state: directory
+    path: "{{ announcer_configuration_path }}"
+    owner: root
+    group: root
+    mode: '755'
+
+- name: copying credentials configuration file for systemd service unit(es)
+  template:
+    src: 'srv-announcer.env.j2'
+    dest: "{{ announcer_environment_variables_path }}"
+    owner: root
+    group: root
+    mode: '600'
+  register: unit_conf_srva
+
 - name: copying systemd service unit(es) to announce SRV record(s)
   template:
     src: 'srv-announcer.service.j2'

--- a/roles/srv-announcer/tasks/configure.yml
+++ b/roles/srv-announcer/tasks/configure.yml
@@ -1,0 +1,9 @@
+- name: copying systemd service unit(es) to announce SRV record(s)
+  template:
+    src: 'srv-announcer.service.j2'
+    dest: "/etc/systemd/system/{{ service_name }}.{{ item.key }}.service"
+    owner: root
+    group: root
+    mode: '644'
+  loop: "{{ announcer_srv_records | dict2items }}"
+  register: units_srva

--- a/roles/srv-announcer/tasks/configure.yml
+++ b/roles/srv-announcer/tasks/configure.yml
@@ -15,12 +15,11 @@
     mode: '600'
   register: unit_conf_srva
 
-- name: copying systemd service unit(es) to announce SRV record(s)
+- name: copying systemd service unit to announce SRV record(s)
   template:
     src: 'srv-announcer.service.j2'
-    dest: "/etc/systemd/system/{{ srv_announcer_service_name }}.{{ item.key }}.service"
+    dest: "/etc/systemd/system/{{ srv_announcer_service_name }}.service"
     owner: root
     group: root
     mode: '644'
-  loop: "{{ srv_announcer_srv_records | dict2items }}"
-  register: units_srva
+  register: unit_srva

--- a/roles/srv-announcer/tasks/configure.yml
+++ b/roles/srv-announcer/tasks/configure.yml
@@ -13,7 +13,7 @@
     owner: root
     group: root
     mode: '600'
-  register: unit_conf_srva
+  register: env_srv_announcer
 
 - name: copying systemd service unit to announce SRV record(s)
   template:
@@ -22,7 +22,7 @@
     owner: root
     group: root
     mode: '644'
-  register: unit_srva
+  register: unit_srv_announcer
 
 - name: copying systemd slice unit to manage SRV annoucer resources
   template:
@@ -31,4 +31,4 @@
     owner: root
     group: root
     mode: '644'
-  register: slice_srva
+  register: slice_srv_announcer

--- a/roles/srv-announcer/tasks/configure.yml
+++ b/roles/srv-announcer/tasks/configure.yml
@@ -1,7 +1,7 @@
 - name: creating srv-announcer configuration path
   file:
     state: directory
-    path: "{{ announcer_configuration_path }}"
+    path: "{{ srv_announcer_configuration_path }}"
     owner: root
     group: root
     mode: '755'
@@ -9,7 +9,7 @@
 - name: copying credentials configuration file for systemd service unit(es)
   template:
     src: 'srv-announcer.env.j2'
-    dest: "{{ announcer_environment_variables_path }}"
+    dest: "{{ srv_announcer_environment_variables_path }}"
     owner: root
     group: root
     mode: '600'
@@ -18,9 +18,9 @@
 - name: copying systemd service unit(es) to announce SRV record(s)
   template:
     src: 'srv-announcer.service.j2'
-    dest: "/etc/systemd/system/{{ service_name }}.{{ item.key }}.service"
+    dest: "/etc/systemd/system/{{ srv_announcer_service_name }}.{{ item.key }}.service"
     owner: root
     group: root
     mode: '644'
-  loop: "{{ announcer_srv_records | dict2items }}"
+  loop: "{{ srv_announcer_srv_records | dict2items }}"
   register: units_srva

--- a/roles/srv-announcer/tasks/finalize.yml
+++ b/roles/srv-announcer/tasks/finalize.yml
@@ -3,6 +3,6 @@
 #
 - name: ensuring that the state of systemd service unit(es) is consistent
   file:
-    dest: "/etc/systemd/system/{{ service_name }}.{{ item.key }}.service"
+    dest: "/etc/systemd/system/{{ srv_announcer_service_name }}.{{ item.key }}.service"
     state: "{{ 'absent' if (item.value.deprecated | default(False)) else 'file' }}"
-  loop: "{{ announcer_srv_records | dict2items }}"
+  loop: "{{ srv_announcer_srv_records | dict2items }}"

--- a/roles/srv-announcer/tasks/finalize.yml
+++ b/roles/srv-announcer/tasks/finalize.yml
@@ -1,0 +1,8 @@
+# NOTE: since the template module does not provide a way to remove the rendered file,
+#       this task will ensure that the configuration is reflected in the filesystem
+#
+- name: ensuring that the state of systemd service unit(es) is consistent
+  file:
+    dest: "/etc/systemd/system/{{ service_name }}.{{ item.key }}.service"
+    state: "{{ 'absent' if (item.value.deprecated | default(False)) else 'file' }}"
+  loop: "{{ announcer_srv_records | dict2items }}"

--- a/roles/srv-announcer/tasks/finalize.yml
+++ b/roles/srv-announcer/tasks/finalize.yml
@@ -1,8 +1,0 @@
-# NOTE: since the template module does not provide a way to remove the rendered file,
-#       this task will ensure that the configuration is reflected in the filesystem
-#
-- name: ensuring that the state of systemd service unit(es) is consistent
-  file:
-    dest: "/etc/systemd/system/{{ srv_announcer_service_name }}.{{ item.key }}.service"
-    state: "{{ 'absent' if (item.value.deprecated | default(False)) else 'file' }}"
-  loop: "{{ srv_announcer_srv_records | dict2items }}"

--- a/roles/srv-announcer/tasks/install.yml
+++ b/roles/srv-announcer/tasks/install.yml
@@ -37,14 +37,14 @@
     src: "{{ srv_announcer_artifact_target_path }}"
     dest: '/tmp/'
     list_files: yes
-  register: unpacked
+  register: unpacked_srv_announcer
 
 - name: copying {{ srv_announcer_service_name }} executable to right location
   copy:
-    src: "{{ unpacked.dest }}{{ unpacked.files[0] }}"
+    src: "{{ unpacked_srv_announcer.dest }}{{ unpacked_srv_announcer.files[0] }}"
     remote_src: yes
     dest: "{{ srv_announcer_bin_path }}"
-  register: binary_srva
+  register: binary_srv_announcer
 
 - name: ensuring executable state
   file:

--- a/roles/srv-announcer/tasks/install.yml
+++ b/roles/srv-announcer/tasks/install.yml
@@ -1,0 +1,53 @@
+- name: copying {{ service_name }} artifact
+  copy:
+    src: "{{ sft_artifact_file_path }}"
+    dest: "{{ announcer_artifact_target_path }}"
+  when:
+    - announcer_artifact_file_path is defined
+    - announcer_version is not defined
+    - announce_artifact_file_url is not defined
+    - announce_artifact_checksum is not defined
+
+- name: downloading {{ service_name }} artifact by version
+  get_url:
+    url: "{{ announcer_download_base_url }}/{{ announcer_artifact_basename }}.tar.gz"
+    checksum: "sha256:{{ announcer_versions[ announcer_version ][ announcer_platform ~ '_' ~ announcer_arch ] }}"
+    dest: "{{ announcer_artifact_target_path }}"
+  when:
+    - announcer_version is defined
+    - announcer_artifact_file_path is not defined
+    - announce_artifact_file_url is not defined
+    - announce_artifact_checksum is not defined
+
+- name: downloading {{ service_name }} artifact by URL
+  get_url:
+    url: "{{ announce_artifact_file_url }}"
+    checksum: "sha256:{{ announce_artifact_checksum }}"
+    dest: "{{ announcer_artifact_target_path }}"
+  when:
+    - announce_artifact_file_url is defined
+    - announce_artifact_checksum is defined
+    - announcer_version is not defined
+    - announcer_artifact_file_path is not defined
+
+
+- name: unpacking artifact
+  unarchive:
+    remote_src: yes
+    src: "{{ announcer_artifact_target_path }}"
+    dest: '/tmp/'
+    list_files: yes
+  register: unpacked
+
+- name: copying {{ service_name }} executable to right location
+  copy:
+    src: "{{ unpacked.dest }}{{ unpacked.files[0] }}"
+    remote_src: yes
+    dest: "{{ announcer_bin_path }}"
+  register: binary_srva
+
+- name: ensuring executable state
+  file:
+    path: "{{ announcer_bin_path }}"
+    state: 'file'
+    mode: '755'

--- a/roles/srv-announcer/tasks/install.yml
+++ b/roles/srv-announcer/tasks/install.yml
@@ -1,53 +1,53 @@
-- name: copying {{ service_name }} artifact
+- name: copying {{ srv_announcer_service_name }} artifact
   copy:
     src: "{{ sft_artifact_file_path }}"
-    dest: "{{ announcer_artifact_target_path }}"
+    dest: "{{ srv_announcer_artifact_target_path }}"
   when:
-    - announcer_artifact_file_path is defined
-    - announcer_version is not defined
-    - announce_artifact_file_url is not defined
-    - announce_artifact_checksum is not defined
+    - srv_announcer_artifact_file_path is defined
+    - srv_announcer_version is not defined
+    - srv_announcer_artifact_file_url is not defined
+    - srv_announcer_artifact_checksum is not defined
 
-- name: downloading {{ service_name }} artifact by version
+- name: downloading {{ srv_announcer_service_name }} artifact by version
   get_url:
-    url: "{{ announcer_download_base_url }}/{{ announcer_artifact_basename }}.tar.gz"
-    checksum: "sha256:{{ announcer_versions[ announcer_version ][ announcer_platform ~ '_' ~ announcer_arch ] }}"
-    dest: "{{ announcer_artifact_target_path }}"
+    url: "{{ srv_announcer_download_base_url }}/{{ srv_announcer_artifact_basename }}.tar.gz"
+    checksum: "sha256:{{ srv_announcer_versions[ srv_announcer_version ][ srv_announcer_platform ~ '_' ~ srv_announcer_arch ] }}"
+    dest: "{{ srv_announcer_artifact_target_path }}"
   when:
-    - announcer_version is defined
-    - announcer_artifact_file_path is not defined
-    - announce_artifact_file_url is not defined
-    - announce_artifact_checksum is not defined
+    - srv_announcer_version is defined
+    - srv_announcer_artifact_file_path is not defined
+    - srv_announcer_artifact_file_url is not defined
+    - srv_announcer_artifact_checksum is not defined
 
-- name: downloading {{ service_name }} artifact by URL
+- name: downloading {{ srv_announcer_service_name }} artifact by URL
   get_url:
-    url: "{{ announce_artifact_file_url }}"
-    checksum: "sha256:{{ announce_artifact_checksum }}"
-    dest: "{{ announcer_artifact_target_path }}"
+    url: "{{ srv_announcer_artifact_file_url }}"
+    checksum: "sha256:{{ srv_announcer_artifact_checksum }}"
+    dest: "{{ srv_announcer_artifact_target_path }}"
   when:
-    - announce_artifact_file_url is defined
-    - announce_artifact_checksum is defined
-    - announcer_version is not defined
-    - announcer_artifact_file_path is not defined
+    - srv_announcer_artifact_file_url is defined
+    - srv_announcer_artifact_checksum is defined
+    - srv_announcer_version is not defined
+    - srv_announcer_artifact_file_path is not defined
 
 
 - name: unpacking artifact
   unarchive:
     remote_src: yes
-    src: "{{ announcer_artifact_target_path }}"
+    src: "{{ srv_announcer_artifact_target_path }}"
     dest: '/tmp/'
     list_files: yes
   register: unpacked
 
-- name: copying {{ service_name }} executable to right location
+- name: copying {{ srv_announcer_service_name }} executable to right location
   copy:
     src: "{{ unpacked.dest }}{{ unpacked.files[0] }}"
     remote_src: yes
-    dest: "{{ announcer_bin_path }}"
+    dest: "{{ srv_announcer_bin_path }}"
   register: binary_srva
 
 - name: ensuring executable state
   file:
-    path: "{{ announcer_bin_path }}"
+    path: "{{ srv_announcer_bin_path }}"
     state: 'file'
     mode: '755'

--- a/roles/srv-announcer/tasks/main.yml
+++ b/roles/srv-announcer/tasks/main.yml
@@ -3,3 +3,27 @@
 
 - name: installing service
   import_tasks: install.yml
+
+- name: configuring service
+  import_tasks: configure.yml
+
+- name: starting service
+  import_tasks: start.yml
+
+- name: finalizing service
+  import_tasks: finalize.yml
+
+
+# NOTE: when staring a service managed by systemd its initial state is
+#       'active' and 'running' until the start timeout has passed, so
+#       the `is-active` test requires an initial delay. Typically the
+#       test.yml tasks are called independently, which implies a natural
+#       delay already.
+#       The amount of seconds is `TimeoutStartSec + 1` to ensure that the
+#       service is in a stable state, even it that is 'failed'
+- name: delaying test run to allow services to stabilize
+  pause:
+    seconds: 5
+
+- name: testing service
+  import_tasks: test.yml

--- a/roles/srv-announcer/tasks/main.yml
+++ b/roles/srv-announcer/tasks/main.yml
@@ -10,17 +10,16 @@
 - name: starting service
   import_tasks: start.yml
 
-- name: finalizing service
-  import_tasks: finalize.yml
-
 
 # NOTE: when staring a service managed by systemd its initial state is
 #       'active' and 'running' until the start timeout has passed, so
 #       the `is-active` test requires an initial delay. Typically the
 #       test.yml tasks are called independently, which implies a natural
 #       delay already.
-#       The amount of seconds is `TimeoutStartSec + 1` to ensure that the
-#       service is in a stable state, even it that is 'failed'
+#       The amount of seconds is set to `TimeoutStartSec + 1` to ensure
+#       that the service is in a stable state, when asking, even if that
+#       'failed'. Note that, due to this asynchronous nature, the chosen
+#       delay is error-prone
 - name: delaying test run to allow services to stabilize
   pause:
     seconds: 5

--- a/roles/srv-announcer/tasks/main.yml
+++ b/roles/srv-announcer/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: verifying requirements
+  import_tasks: assert.yml
+
+- name: installing service
+  import_tasks: install.yml

--- a/roles/srv-announcer/tasks/start.yml
+++ b/roles/srv-announcer/tasks/start.yml
@@ -1,26 +1,15 @@
 - name: starting service(s) - {{ srv_announcer_service_name }}
   systemd:
-    name: "{{ srv_announcer_service_name }}.{{ item.item.key }}"
+    name: "{{ srv_announcer_service_name }}"
     enabled: yes
     state: >-
       {{
         'restarted' if
           (binary_srva is defined and binary_srva.changed)
           or
-          (item.changed is defined and item.changed)
+          (unit_srva is defined and unit_srva.changed)
           or
           (unit_conf_srva is defined and unit_conf_srva.changed)
         else 'started'
       }}
-    daemon_reload: "{{ 'yes' if item.changed is defined and item.changed else 'no' }}"
-  when: (item.item.value.deprecated | default(False)) == False
-  loop: "{{ units_srva.results }}"
-
-- name: stopping service(s) - {{ srv_announcer_service_name }}
-  systemd:
-    name: "{{ srv_announcer_service_name }}.{{ item.key }}"
-    enabled: no
-    state: stopped
-    daemon_reload: no
-  when: item.value.deprecated is defined and (item.value.deprecated | bool) == True
-  loop: "{{ srv_announcer_srv_records | dict2items }}"
+    daemon_reload: "{{ 'yes' if unit_srva is defined and unit_srva.changed else 'no' }}"

--- a/roles/srv-announcer/tasks/start.yml
+++ b/roles/srv-announcer/tasks/start.yml
@@ -8,6 +8,8 @@
           (binary_srva is defined and binary_srva.changed)
           or
           (item.changed is defined and item.changed)
+          or
+          (unit_conf_srva is defined and unit_conf_srva.changed)
         else 'started'
       }}
     daemon_reload: "{{ 'yes' if item.changed is defined and item.changed else 'no' }}"

--- a/roles/srv-announcer/tasks/start.yml
+++ b/roles/srv-announcer/tasks/start.yml
@@ -1,0 +1,24 @@
+- name: starting service(s) - {{ service_name }}
+  systemd:
+    name: "{{ service_name }}.{{ item.item.key }}"
+    enabled: yes
+    state: >-
+      {{
+        'restarted' if
+          (binary_srva is defined and binary_srva.changed)
+          or
+          (item.changed is defined and item.changed)
+        else 'started'
+      }}
+    daemon_reload: "{{ 'yes' if item.changed is defined and item.changed else 'no' }}"
+  when: (item.item.value.deprecated | default(False)) == False
+  loop: "{{ units_srva.results }}"
+
+- name: stopping service(s) - {{ service_name }}
+  systemd:
+    name: "{{ service_name }}.{{ item.key }}"
+    enabled: no
+    state: stopped
+    daemon_reload: no
+  when: item.value.deprecated is defined and (item.value.deprecated | bool) == True
+  loop: "{{ announcer_srv_records | dict2items }}"

--- a/roles/srv-announcer/tasks/start.yml
+++ b/roles/srv-announcer/tasks/start.yml
@@ -5,20 +5,20 @@
     state: >-
       {{
         'restarted' if
-          (binary_srva is defined and binary_srva.changed)
+          (binary_srv_announcer is defined and binary_srv_announcer.changed)
           or
-          (unit_srva is defined and unit_srva.changed)
+          (unit_srv_announcer is defined and unit_srv_announcer.changed)
           or
-          (unit_conf_srva is defined and unit_conf_srva.changed)
+          (env_srv_announcer is defined and binary_srv_announcer.changed)
           or
-          (slice_srva is defined and slice_srva.changed)
+          (slice_srv_announcer is defined and slice_srv_announcer.changed)
         else 'started'
       }}
     daemon_reload: >-
       {{
         'yes' if
-          (unit_srva is defined and unit_srva.changed)
+          (unit_srv_announcer is defined and unit_srv_announcer.changed)
           or
-          (slice_srva is defined and slice_srva.changed)
+          (slice_srv_announcer is defined and slice_srv_announcer.changed)
         else 'no'
       }}

--- a/roles/srv-announcer/tasks/start.yml
+++ b/roles/srv-announcer/tasks/start.yml
@@ -1,6 +1,6 @@
-- name: starting service(s) - {{ service_name }}
+- name: starting service(s) - {{ srv_announcer_service_name }}
   systemd:
-    name: "{{ service_name }}.{{ item.item.key }}"
+    name: "{{ srv_announcer_service_name }}.{{ item.item.key }}"
     enabled: yes
     state: >-
       {{
@@ -16,11 +16,11 @@
   when: (item.item.value.deprecated | default(False)) == False
   loop: "{{ units_srva.results }}"
 
-- name: stopping service(s) - {{ service_name }}
+- name: stopping service(s) - {{ srv_announcer_service_name }}
   systemd:
-    name: "{{ service_name }}.{{ item.key }}"
+    name: "{{ srv_announcer_service_name }}.{{ item.key }}"
     enabled: no
     state: stopped
     daemon_reload: no
   when: item.value.deprecated is defined and (item.value.deprecated | bool) == True
-  loop: "{{ announcer_srv_records | dict2items }}"
+  loop: "{{ srv_announcer_srv_records | dict2items }}"

--- a/roles/srv-announcer/tasks/start.yml
+++ b/roles/srv-announcer/tasks/start.yml
@@ -10,6 +10,15 @@
           (unit_srva is defined and unit_srva.changed)
           or
           (unit_conf_srva is defined and unit_conf_srva.changed)
+          or
+          (slice_srva is defined and slice_srva.changed)
         else 'started'
       }}
-    daemon_reload: "{{ 'yes' if unit_srva is defined and unit_srva.changed else 'no' }}"
+    daemon_reload: >-
+      {{
+        'yes' if
+          (unit_srva is defined and unit_srva.changed)
+          or
+          (slice_srva is defined and slice_srva.changed)
+        else 'no'
+      }}

--- a/roles/srv-announcer/tasks/test.yml
+++ b/roles/srv-announcer/tasks/test.yml
@@ -1,0 +1,9 @@
+- name: "verifying that service '{{ service_name }}' started successfully"
+  command: "systemctl is-active {{ service_name }}.sft"
+  retries: 6
+  delay: 2
+  register: result
+  until: result.stdout == "active"
+  changed_when: false
+  when: item.value.deprecated | default(False) == False
+  loop: "{{ announcer_srv_records | dict2items }}"

--- a/roles/srv-announcer/tasks/test.yml
+++ b/roles/srv-announcer/tasks/test.yml
@@ -1,9 +1,9 @@
-- name: "verifying that service '{{ service_name }}' started successfully"
-  command: "systemctl is-active {{ service_name }}.sft"
+- name: "verifying that service '{{ srv_announcer_service_name }}' started successfully"
+  command: "systemctl is-active {{ srv_announcer_service_name }}.sft"
   retries: 6
   delay: 2
   register: result
   until: result.stdout == "active"
   changed_when: false
   when: item.value.deprecated | default(False) == False
-  loop: "{{ announcer_srv_records | dict2items }}"
+  loop: "{{ srv_announcer_srv_records | dict2items }}"

--- a/roles/srv-announcer/tasks/test.yml
+++ b/roles/srv-announcer/tasks/test.yml
@@ -1,9 +1,7 @@
 - name: "verifying that service '{{ srv_announcer_service_name }}' started successfully"
-  command: "systemctl is-active {{ srv_announcer_service_name }}.sft"
+  command: "systemctl is-active {{ srv_announcer_service_name }}"
   retries: 6
   delay: 2
   register: result
   until: result.stdout == "active"
   changed_when: false
-  when: item.value.deprecated | default(False) == False
-  loop: "{{ srv_announcer_srv_records | dict2items }}"

--- a/roles/srv-announcer/templates/discovery.slice.j2
+++ b/roles/srv-announcer/templates/discovery.slice.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=Reserve resources for health checking and (de-)publishing target service
+
+Before=slices.target
+
+
+[Slice]
+CPUAccounting=true
+MemoryAccounting=true
+
+# NOTE: assuming it defaults to 100 everywhere else, this ensures that
+#       even when CPU is eaten up by other processes the srv-announcer
+#       has priority
+CPUWeight=200
+
+# NOTE: give the srv-announcer enough air to breath to de-publish the
+#       target in case it is unresponsive due to resource exhaustion
+MemoryMin=64M
+# NOTE: prevent processes in this slide to swap
+MemorySwapMax=0

--- a/roles/srv-announcer/templates/srv-announcer.env.j2
+++ b/roles/srv-announcer/templates/srv-announcer.env.j2
@@ -1,0 +1,3 @@
+AWS_ACCESS_KEY_ID={{ announcer_aws_key_id }}
+AWS_SECRET_ACCESS_KEY={{ announcer_aws_access_key }}
+AWS_DEFAULT_REGION={{ announcer_aws_region }}

--- a/roles/srv-announcer/templates/srv-announcer.env.j2
+++ b/roles/srv-announcer/templates/srv-announcer.env.j2
@@ -1,3 +1,3 @@
-AWS_ACCESS_KEY_ID={{ announcer_aws_key_id }}
-AWS_SECRET_ACCESS_KEY={{ announcer_aws_access_key }}
-AWS_DEFAULT_REGION={{ announcer_aws_region }}
+AWS_ACCESS_KEY_ID={{ srv_announcer_aws_key_id }}
+AWS_SECRET_ACCESS_KEY={{ srv_announcer_aws_access_key }}
+AWS_DEFAULT_REGION={{ srv_announcer_aws_region }}

--- a/roles/srv-announcer/templates/srv-announcer.service.j2
+++ b/roles/srv-announcer/templates/srv-announcer.service.j2
@@ -12,9 +12,7 @@ Restart=always
 
 DynamicUser=yes
 
-Environment="AWS_ACCESS_KEY_ID={{ announcer_aws_key_id }}" \
-            "AWS_SECRET_ACCESS_KEY={{ announcer_aws_access_key }}" \
-            "AWS_DEFAULT_REGION={{ announcer_aws_region }}"
+EnvironmentFile={{ announcer_environment_variables_path }}
 
 ExecStart={{ announcer_bin_path }} \
             --zone-name '{{ announcer_zone_domain }}' \

--- a/roles/srv-announcer/templates/srv-announcer.service.j2
+++ b/roles/srv-announcer/templates/srv-announcer.service.j2
@@ -10,6 +10,8 @@ Wants=network-online.target
 TimeoutStartSec=4
 Restart=always
 
+Slice=discovery.slice
+
 DynamicUser=yes
 
 EnvironmentFile={{ srv_announcer_environment_variables_path }}

--- a/roles/srv-announcer/templates/srv-announcer.service.j2
+++ b/roles/srv-announcer/templates/srv-announcer.service.j2
@@ -1,0 +1,32 @@
+[Unit]
+Description={{ service_name }}.{{ item.key }} - Publish an SRV record on the DNS server
+
+
+After=network-online.target
+Wants=network-online.target
+
+
+[Service]
+TimeoutStartSec=4
+Restart=always
+
+DynamicUser=yes
+
+Environment="AWS_ACCESS_KEY_ID={{ announcer_aws_key_id }}" \
+            "AWS_SECRET_ACCESS_KEY={{ announcer_aws_access_key }}" \
+            "AWS_DEFAULT_REGION={{ announcer_aws_region }}"
+
+ExecStart={{ announcer_bin_path }} \
+            --zone-name '{{ announcer_zone_domain }}' \
+            --srv-record-name '{{ item.value.name }}' \
+            --srv-record-ttl '{{ announcer_record_ttl }}' \
+            --srv-record-priority '{{ announcer_record_priority }}' \
+            --srv-record-weight '{{ announcer_record_weight }}' \
+            --srv-record-port '{{ announcer_record_port }}' \
+            --srv-record-target '{{ item.value.target }}' \
+            --check-interval '30s' \
+            --check-timeout '6s'
+
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/srv-announcer/templates/srv-announcer.service.j2
+++ b/roles/srv-announcer/templates/srv-announcer.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description={{ srv_announcer_service_name }}.{{ item.key }} - Publish an SRV record on the DNS server
+Description={{ srv_announcer_service_name }} - Publish an SRV record on the DNS server
 
 
 After=network-online.target
@@ -16,12 +16,12 @@ EnvironmentFile={{ srv_announcer_environment_variables_path }}
 
 ExecStart={{ srv_announcer_bin_path }} \
             --zone-name '{{ srv_announcer_zone_domain }}' \
-            --srv-record-name '{{ item.value.name }}.{{ srv_announcer_zone_domain }}' \
+            --srv-record-name '{{ srv_announcer_record_name }}.{{ srv_announcer_zone_domain }}' \
             --srv-record-ttl '{{ srv_announcer_record_ttl }}' \
             --srv-record-priority '{{ srv_announcer_record_priority }}' \
             --srv-record-weight '{{ srv_announcer_record_weight }}' \
             --srv-record-port '{{ srv_announcer_record_port }}' \
-            --srv-record-target '{{ item.value.target }}' \
+            --srv-record-target '{{ srv_announcer_record_target }}' \
             --check-interval '30s' \
             --check-timeout '6s'
 

--- a/roles/srv-announcer/templates/srv-announcer.service.j2
+++ b/roles/srv-announcer/templates/srv-announcer.service.j2
@@ -18,7 +18,7 @@ Environment="AWS_ACCESS_KEY_ID={{ announcer_aws_key_id }}" \
 
 ExecStart={{ announcer_bin_path }} \
             --zone-name '{{ announcer_zone_domain }}' \
-            --srv-record-name '{{ item.value.name }}' \
+            --srv-record-name '{{ item.value.name }}.{{ announcer_zone_domain }}' \
             --srv-record-ttl '{{ announcer_record_ttl }}' \
             --srv-record-priority '{{ announcer_record_priority }}' \
             --srv-record-weight '{{ announcer_record_weight }}' \

--- a/roles/srv-announcer/templates/srv-announcer.service.j2
+++ b/roles/srv-announcer/templates/srv-announcer.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description={{ service_name }}.{{ item.key }} - Publish an SRV record on the DNS server
+Description={{ srv_announcer_service_name }}.{{ item.key }} - Publish an SRV record on the DNS server
 
 
 After=network-online.target
@@ -12,15 +12,15 @@ Restart=always
 
 DynamicUser=yes
 
-EnvironmentFile={{ announcer_environment_variables_path }}
+EnvironmentFile={{ srv_announcer_environment_variables_path }}
 
-ExecStart={{ announcer_bin_path }} \
-            --zone-name '{{ announcer_zone_domain }}' \
-            --srv-record-name '{{ item.value.name }}.{{ announcer_zone_domain }}' \
-            --srv-record-ttl '{{ announcer_record_ttl }}' \
-            --srv-record-priority '{{ announcer_record_priority }}' \
-            --srv-record-weight '{{ announcer_record_weight }}' \
-            --srv-record-port '{{ announcer_record_port }}' \
+ExecStart={{ srv_announcer_bin_path }} \
+            --zone-name '{{ srv_announcer_zone_domain }}' \
+            --srv-record-name '{{ item.value.name }}.{{ srv_announcer_zone_domain }}' \
+            --srv-record-ttl '{{ srv_announcer_record_ttl }}' \
+            --srv-record-priority '{{ srv_announcer_record_priority }}' \
+            --srv-record-weight '{{ srv_announcer_record_weight }}' \
+            --srv-record-port '{{ srv_announcer_record_port }}' \
             --srv-record-target '{{ item.value.target }}' \
             --check-interval '30s' \
             --check-timeout '6s'

--- a/roles/srv-announcer/vars/main.yml
+++ b/roles/srv-announcer/vars/main.yml
@@ -1,0 +1,17 @@
+# NOTE: variables set here are considered to be CONSTANTS due to high precedence
+
+service_name: "{{ role_name }}"
+
+announcer_download_base_url: "https://github.com/wireapp/srv-announcer/releases/download/{{ announcer_version }}"
+announcer_artifact_basename: "srv-announcer_{{ announcer_version }}_{{ announcer_platform }}-{{ announcer_arch }}"
+announcer_artifact_target_path: '/tmp/srv-announcer.tar.gz'
+announcer_bin_path: '/usr/local/bin/srv-announcer'
+
+# NOTE: no other architecture or platform supported (yet)
+announcer_platform: 'linux'
+announcer_arch: 'amd64'
+
+
+announcer_versions:
+  v0.1.0:
+    linux_amd64: '5dda66cfa779f06495db7b6495af6456dd1c2f3da22adbb36dc8ae3c130d7c8f'

--- a/roles/srv-announcer/vars/main.yml
+++ b/roles/srv-announcer/vars/main.yml
@@ -6,6 +6,8 @@ announcer_download_base_url: "https://github.com/wireapp/srv-announcer/releases/
 announcer_artifact_basename: "srv-announcer_{{ announcer_version }}_{{ announcer_platform }}-{{ announcer_arch }}"
 announcer_artifact_target_path: '/tmp/srv-announcer.tar.gz'
 announcer_bin_path: '/usr/local/bin/srv-announcer'
+announcer_configuration_path: '/usr/local/etc/srv-announcer'
+announcer_environment_variables_path: "{{ announcer_configuration_path }}/credentials.env"
 
 # NOTE: no other architecture or platform supported (yet)
 announcer_platform: 'linux'

--- a/roles/srv-announcer/vars/main.yml
+++ b/roles/srv-announcer/vars/main.yml
@@ -1,19 +1,19 @@
 # NOTE: variables set here are considered to be CONSTANTS due to high precedence
 
-service_name: "{{ role_name }}"
+srv_announcer_service_name: "{{ role_name }}"
 
-announcer_download_base_url: "https://github.com/wireapp/srv-announcer/releases/download/{{ announcer_version }}"
-announcer_artifact_basename: "srv-announcer_{{ announcer_version }}_{{ announcer_platform }}-{{ announcer_arch }}"
-announcer_artifact_target_path: '/tmp/srv-announcer.tar.gz'
-announcer_bin_path: '/usr/local/bin/srv-announcer'
-announcer_configuration_path: '/usr/local/etc/srv-announcer'
-announcer_environment_variables_path: "{{ announcer_configuration_path }}/credentials.env"
+srv_announcer_download_base_url: "https://github.com/wireapp/srv-announcer/releases/download/{{ srv_announcer_version }}"
+srv_announcer_artifact_basename: "srv-announcer_{{ srv_announcer_version }}_{{ srv_announcer_platform }}-{{ srv_announcer_arch }}"
+srv_announcer_artifact_target_path: '/tmp/srv-announcer.tar.gz'
+srv_announcer_bin_path: '/usr/local/bin/srv-announcer'
+srv_announcer_configuration_path: '/usr/local/etc/srv-announcer'
+srv_announcer_environment_variables_path: "{{ srv_announcer_configuration_path }}/credentials.env"
 
 # NOTE: no other architecture or platform supported (yet)
-announcer_platform: 'linux'
-announcer_arch: 'amd64'
+srv_announcer_platform: 'linux'
+srv_announcer_arch: 'amd64'
 
 
-announcer_versions:
+srv_announcer_versions:
   v0.1.0:
     linux_amd64: '5dda66cfa779f06495db7b6495af6456dd1c2f3da22adbb36dc8ae3c130d7c8f'


### PR DESCRIPTION
The role implements 3 main steps:

1. fetch and executable and bring it in place
2. confiugure systemd service
3. start and test the service

Ii is worth noting that for now the `srv-announcer` can only manage one SRV record, whereas it might be necessary to announce items on multiple SRV records (e.g. `_sft.` and `_sft-metrics.`). The role allows to configure this, which will result in multiple instances of the `srv-announcer` but with slightly different configuration. For more information, please refer to the comments next to the corresponding variable `announcer_records`.