### PR TITLE
[role:sft-server] Minor improvements

### DIFF
--- a/roles/sft-server/defaults/main.yml
+++ b/roles/sft-server/defaults/main.yml
@@ -58,6 +58,12 @@ sft_unsupported_client_versions: []     # each client version is supported
 #  - '<5.2.10'
 #  - '6.1.3'
 
+# NOTE: for debugging purposes it might be desired to prevent log suppression
+# INFO: The systemd options for this behaviour are only supported from systemd v240 onward;
+#       if an older version is being used, the desired behaviour can be achieved by setting
+#       https://www.freedesktop.org/software/systemd/man/journald.conf.html#RateLimitIntervalSec=
+sft_prevent_log_suppression: false
+
 metrics_enabled: false
 
 certbot_enabled: true   # implies automated renewal

--- a/roles/sft-server/tasks/main.yml
+++ b/roles/sft-server/tasks/main.yml
@@ -13,5 +13,16 @@
 - name: exposing service
   import_tasks: traffic.yml
 
+# NOTE: when staring a service managed by systemd its initial state is
+#       'active' and 'running' until the start timeout has passed, so
+#       the `is-active` test requires an initial delay. Typically the
+#       test.yml tasks are called independently, which implies a natural
+#       delay already.
+#       The amount of seconds is `TimeoutStartSec + 1` to ensure that the
+#       service is in a stable state, even it that is 'failed'
+- name: delaying test run to allow services to stabilize
+  pause:
+    seconds: 5
+
 - name: testing service
   import_tasks: test.yml

--- a/roles/sft-server/tasks/start.yml
+++ b/roles/sft-server/tasks/start.yml
@@ -2,5 +2,12 @@
   systemd:
     name: "{{ service_name }}"
     enabled: yes
-    state: "{{ 'restarted' if binary_sftd is defined and binary_sftd.changed else 'started' }}"
+    state: >-
+      {{
+        'restarted' if
+          (binary_sftd is defined and binary_sftd.changed)
+          or
+          (unit_sftd is defined and unit_sftd.changed)
+        else 'started'
+      }}
     daemon_reload: "{{ 'yes' if unit_sftd is defined and unit_sftd.changed else 'no' }}"

--- a/roles/sft-server/tasks/test.yml
+++ b/roles/sft-server/tasks/test.yml
@@ -12,3 +12,11 @@
     timeout: 6
   register: response
   failed_when: response.status != 200
+
+- name: "verifying that service 'nginx' runs successfully"
+  command: "systemctl is-active nginx"
+  retries: 6
+  delay: 2
+  register: result
+  until: result.stdout == "active"
+  changed_when: false

--- a/roles/sft-server/templates/coredump.conf.j2
+++ b/roles/sft-server/templates/coredump.conf.j2
@@ -2,8 +2,9 @@
 # NOTE: core dump files end up in /var/lib/systemd/coredump/; use `coredumpctl` to interact
 # docs: https://www.freedesktop.org/software/systemd/man/coredump.conf.html#
 
-ProcessSizeMax={{ systemd_coredump_max_file_size }}
+Storage=external
 ExternalSizeMax={{ systemd_coredump_max_file_size }}
+ProcessSizeMax={{ systemd_coredump_max_file_size }}
 
 # NOTE: Giving everything else (metrics, web server, sidecar, and the rest of the system) a bit
 #       more headroom than just the default of 10%. Since this is a relative boundary, for small

--- a/roles/sft-server/templates/nginx.service.override.j2
+++ b/roles/sft-server/templates/nginx.service.override.j2
@@ -1,3 +1,4 @@
 [Service]
 LimitNOFILE={{ nginx_rlimit_nofile }}
 ExecStartPre=/usr/sbin/nginx -t
+ExecReload=/usr/sbin/nginx -t

--- a/roles/sft-server/templates/sftd.service.j2
+++ b/roles/sft-server/templates/sftd.service.j2
@@ -16,12 +16,14 @@ LimitCORE=0:infinity
 
 LimitNOFILE={{ sftd_limit_nofile }}
 
+{% if sft_prevent_log_suppression | bool %}
 # NOTE: disable limit rate for logs to prevent journald from suppressing
 #       when throughput increases. It requires both to be overridden,
 #       otherwise journald would stop handling logs after the attempt
 #       to suppress for the fist time after service start
 LogRateLimitIntervalSec=0
 LogRateLimitBurst=0
+{% endif %}
 
 DynamicUser=yes
 


### PR DESCRIPTION
* Add default to coredump config in order to make the relation between
  the options more clear
* introduce 'sft_prevent_log_suppression' to disable log suppression for sftd
  (see comment)
* introduce a delay before the testing task (see comment)
* set reload behaviour of nginx.service explicitly to
   a) have proper reload behaviour to begin with
   b) fail early if config syntax in broken
  and because 'ExecStartPre' is not executed when running 'systemctl reload nginx'
* add a test to verify whether nginx runs properly