### PR TITLE
[role:sft-server] Redo nginx reload behaviour

### DIFF
--- a/roles/sft-server/templates/nginx.service.override.j2
+++ b/roles/sft-server/templates/nginx.service.override.j2
@@ -2,7 +2,17 @@
 LimitNOFILE={{ nginx_rlimit_nofile }}
 
 ExecStartPre=/usr/sbin/nginx -t
+
+# NOTE: redefine reload behaviour to cause configuration management
+#       fail early if Nginx configuration files are flawed
+ExecReload=
 ExecReload=/usr/sbin/nginx -t
+ExecReload=/usr/sbin/nginx -s reload
+
+# NOTE: this is a workaround that - as a side effect - my cause Nginx
+#       end up in an undesired state for some cases
+# ISSUE: https://bugs.launchpad.net/ubuntu/+source/nginx/+bug/1581864
+ExecStartPost=/bin/sleep 0.1
 
 # NOTE: defaults to 'inherit' which leads to error messages not
 #       appearing if nginx.conf is set to 'error_log: stderr'


### PR DESCRIPTION
In order to be more config mgmt friendly, this redefines how
systemd reloads nginx.

Additionally, it introduces a fix for an issue on some linux
distributions indicated in the logs by

> nginx.service: Failed to read PID from file /run/nginx.pid: Invalid argument