### PR TITLE
[role:sft-server] Copy list of dependencies into the top-level

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,4 +2,6 @@
 #       even though this is currently not a Ansible collection
 
 galaxy_info: {}
-dependencies: []
+dependencies:
+  - role: cloudalchemy.node-exporter
+    when: 'False'


### PR DESCRIPTION
This is a rather odd one, but part of working around the fact
that we do not yet support Ansible 2.9 and thus collections.
But wan to have multiple roles in one repository.

Every dependency that each role in /roles has must be listed in
/meta/main.yml too. Otherwise they are not picked up / visible to
'ansible-galaxy' when installing the roles in this repository.

That is one part of the story. You might ask: but why then not
defining them on the top-level only and be done. Well, the other
part of the story is, that

a) when applying a role in a play, Ansible recognizes the entries
in 'dependencies' in /roles/$role/meta/main.yml and apply
all of them before applying the dependant role itself. We want
this behaviour.

b) Molecule. When testing individual roles (/roles/$role), Molecule
needs to know be able to determine (and download) its dependencies, too.
It does not see /meta/main.yml, unfortunately.

NOTE: the 'when: False' is to make sure that the dependency is only
      downloaded but never applied. THis is what the dependencies
      array in 'meta' within the role is for.