### PR TITLE
[roles:sft-server] Enforce downloading and copying artifact

### DIFF
--- a/roles/sft-server/tasks/install.yml
+++ b/roles/sft-server/tasks/install.yml
@@ -9,11 +9,11 @@
 - name: download SFT artifact
   get_url:
     url: "{{ sft_artifact_file_url }}"
+    checksum: "sha256:{{ sft_artifact_checksum }}"
     dest: "{{ sft_artifact_target_path }}"
-    # FUTUREWORK: check sha256sum
-    # sha256sum: "{{ sft_artifact_checksum | default(omit) }}"
   when:
     - sft_artifact_file_url is defined
+    - sft_artifact_checksum is defined
 
 - name: unpacking artifact
   unarchive:


### PR DESCRIPTION
Before, sftd did not get updated, even though 'sft_artifact_file_url'
changed. Compared to 'copy' (defaults to force: yes), w/o providing a
checksum causes 'get_url' to behave inconsistently. To make 'get_url'
downloading the artifact even though the location already exists, this
change allows to provide a checksum.