### PR TITLE
roles/srv-announcer: simplify fetching

### DIFF
--- a/roles/srv-announcer/defaults/main.yml
+++ b/roles/srv-announcer/defaults/main.yml
@@ -3,15 +3,6 @@
 
 # INFO: The following variables are MANDATORY or will be tested for existence
 
-# There are three different ways to define which version is going to be installed.
-# All of them are mutual exclusive.
-# 1.
-# srv_announcer_artifact_file_path: local path in filesystem
-#
-# 2.
-# srv_announcer_version: string of a specific release version
-#
-# 3.
 # srv_announcer_artifact_file_url: URL
 # srv_announcer_artifact_checksum: value
 

--- a/roles/srv-announcer/defaults/main.yml
+++ b/roles/srv-announcer/defaults/main.yml
@@ -3,8 +3,9 @@
 
 # INFO: The following variables are MANDATORY or will be tested for existence
 
+# Define which version is going to be installed.
 # srv_announcer_artifact_file_url: URL
-# srv_announcer_artifact_checksum: value
+# srv_announcer_artifact_checksum: URL or value
 
 # DOCS: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
 # srv_announcer_aws_key_id: String

--- a/roles/srv-announcer/tasks/install.yml
+++ b/roles/srv-announcer/tasks/install.yml
@@ -1,23 +1,31 @@
+- name: creating temporary file
+  tempfile:
+    state: file
+  register: srv_announcer_artifact_file
+
 - name: downloading {{ srv_announcer_service_name }} artifact by URL
   get_url:
     url: "{{ srv_announcer_artifact_file_url }}"
     checksum: "{{ srv_announcer_artifact_checksum }}"
-    dest: "/tmp/srv-announcer.tar.gz"
-  when:
-    - srv_announcer_artifact_file_url is defined
-    - srv_announcer_artifact_checksum is defined
+    dest: "{{ srv_announcer_artifact_file.path }}"
+
+- name: creating temporary directory
+  tempfile:
+    state: directory
+  register: srv_announcer_artifact_destination
 
 - name: unpacking artifact
   unarchive:
     remote_src: yes
-    src: "/tmp/srv-announcer.tar.gz"
-    dest: '/tmp/'
-    list_files: yes
+    src: "{{ srv_announcer_artifact_file.path }}"
+    dest: "{{ srv_announcer_artifact_destination.path }}/"
+    extra_opts:
+      - '--strip-components=1'
   register: unpacked_srv_announcer
 
-- name: copying {{ srv_announcer_service_name }} executable to right location
+- name: copying {{ srv_announcer_service_name }} binary into the right location
   copy:
-    src: "/tmp/srv-announcer.tar.gz"
+    src: "{{ srv_announcer_artifact_destination.path }}/srv-announcer"
     remote_src: yes
     dest: "{{ srv_announcer_bin_path }}"
   register: binary_srv_announcer

--- a/roles/srv-announcer/tasks/install.yml
+++ b/roles/srv-announcer/tasks/install.yml
@@ -1,47 +1,23 @@
-- name: copying {{ srv_announcer_service_name }} artifact
-  copy:
-    src: "{{ sft_artifact_file_path }}"
-    dest: "{{ srv_announcer_artifact_target_path }}"
-  when:
-    - srv_announcer_artifact_file_path is defined
-    - srv_announcer_version is not defined
-    - srv_announcer_artifact_file_url is not defined
-    - srv_announcer_artifact_checksum is not defined
-
-- name: downloading {{ srv_announcer_service_name }} artifact by version
-  get_url:
-    url: "{{ srv_announcer_download_base_url }}/{{ srv_announcer_artifact_basename }}.tar.gz"
-    checksum: "sha256:{{ srv_announcer_versions[ srv_announcer_version ][ srv_announcer_platform ~ '_' ~ srv_announcer_arch ] }}"
-    dest: "{{ srv_announcer_artifact_target_path }}"
-  when:
-    - srv_announcer_version is defined
-    - srv_announcer_artifact_file_path is not defined
-    - srv_announcer_artifact_file_url is not defined
-    - srv_announcer_artifact_checksum is not defined
-
 - name: downloading {{ srv_announcer_service_name }} artifact by URL
   get_url:
     url: "{{ srv_announcer_artifact_file_url }}"
-    checksum: "sha256:{{ srv_announcer_artifact_checksum }}"
-    dest: "{{ srv_announcer_artifact_target_path }}"
+    checksum: "{{ srv_announcer_artifact_checksum }}"
+    dest: "/tmp/srv-announcer.tar.gz"
   when:
     - srv_announcer_artifact_file_url is defined
     - srv_announcer_artifact_checksum is defined
-    - srv_announcer_version is not defined
-    - srv_announcer_artifact_file_path is not defined
-
 
 - name: unpacking artifact
   unarchive:
     remote_src: yes
-    src: "{{ srv_announcer_artifact_target_path }}"
+    src: "/tmp/srv-announcer.tar.gz"
     dest: '/tmp/'
     list_files: yes
   register: unpacked_srv_announcer
 
 - name: copying {{ srv_announcer_service_name }} executable to right location
   copy:
-    src: "{{ unpacked_srv_announcer.dest }}{{ unpacked_srv_announcer.files[0] }}"
+    src: "/tmp/srv-announcer.tar.gz"
     remote_src: yes
     dest: "{{ srv_announcer_bin_path }}"
   register: binary_srv_announcer

--- a/roles/srv-announcer/vars/main.yml
+++ b/roles/srv-announcer/vars/main.yml
@@ -2,20 +2,7 @@
 
 srv_announcer_service_name: "{{ role_name }}"
 
-srv_announcer_download_base_url: "https://github.com/wireapp/srv-announcer/releases/download/{{ srv_announcer_version }}"
-srv_announcer_artifact_basename: "srv-announcer_{{ srv_announcer_version }}_{{ srv_announcer_platform }}-{{ srv_announcer_arch }}"
 srv_announcer_artifact_target_path: '/tmp/srv-announcer.tar.gz'
 srv_announcer_bin_path: '/usr/local/bin/srv-announcer'
 srv_announcer_configuration_path: '/usr/local/etc/srv-announcer'
 srv_announcer_environment_variables_path: "{{ srv_announcer_configuration_path }}/credentials.env"
-
-# NOTE: no other architecture or platform supported (yet)
-srv_announcer_platform: 'linux'
-srv_announcer_arch: 'amd64'
-
-
-srv_announcer_versions:
-  v0.1.0:
-    linux_amd64: '5dda66cfa779f06495db7b6495af6456dd1c2f3da22adbb36dc8ae3c130d7c8f'
-  v0.2.0:
-    linux_amd64: 'aab5d61b682fd809a91a9649fb77a5491e8ccc68183b44b6265d9344646afd0a'


### PR DESCRIPTION
There's few value in providing three different ways to retrieve the srv
announcer. In fact, it's debatable on whether this should belong in this
ansible role at all, given it's something very specific to our
environment (and the lack of service discovery).

Simplify this, by only accepting
```
 - srv_announcer_artifact_file_url
 - srv_announcer_artifact_checksum
```

Which needs to be set from the outside while instantiating this role.

`srv_announcer_artifact_checksum` now is also piped directly to
`get_url.checksum`, meaning it'll need to have the hashing algorithm and
a colon in front.