### PR TITLE
[role:sft-server] Decrease DH keysize default

### DIFF
--- a/roles/sft-server/defaults/main.yml
+++ b/roles/sft-server/defaults/main.yml
@@ -79,4 +79,4 @@ systemd_coredump_enabled: true
 systemd_coredump_max_file_size: '4G'
 
 # diffie-hellman keysize for nginx
-sft_nginx_dh_keysize: 4096
+sft_nginx_dh_keysize: 2048


### PR DESCRIPTION
Since the DH param for Nginx is generated on each machine, it
obviously does not scale, as pointed out by @jschaul. So, a smaller
keysize default is being introduced.