### PR TITLE
[roles:sft-server] Make rate limit configurable

### DIFF
--- a/roles/sft-server/defaults/main.yml
+++ b/roles/sft-server/defaults/main.yml
@@ -82,7 +82,7 @@ systemd_coredump_max_file_size: '4G'
 sft_nginx_dh_keysize: 2048
 
 # NOTE: disabling rate limit might be desired for on-prem scenarios
-sft_nginx_rate_limit_disabled: false
+sft_nginx_rate_limit_enabled: true
 sft_nginx_rate_limit_requests_per_second: 100
 sft_nginx_rate_limit_burst_until: "{{ 2 * sft_nginx_rate_limit_requests_per_second }}"
 sft_nginx_rate_limit_max_connection_per_address: "{{ 3 * sft_nginx_rate_limit_burst_until }}"

--- a/roles/sft-server/defaults/main.yml
+++ b/roles/sft-server/defaults/main.yml
@@ -80,3 +80,9 @@ systemd_coredump_max_file_size: '4G'
 
 # diffie-hellman keysize for nginx
 sft_nginx_dh_keysize: 2048
+
+# NOTE: disabling rate limit might be desired for on-prem scenarios
+sft_nginx_rate_limit_disabled: false
+sft_nginx_rate_limit_requests_per_second: 100
+sft_nginx_rate_limit_burst_until: "{{ 2 * sft_nginx_rate_limit_requests_per_second }}"
+sft_nginx_rate_limit_max_connection_per_address: "{{ 3 * sft_nginx_rate_limit_burst_until }}"

--- a/roles/sft-server/templates/sftd.vhost.conf.j2
+++ b/roles/sft-server/templates/sftd.vhost.conf.j2
@@ -1,5 +1,7 @@
-limit_req_zone "$binary_remote_addr$uri" zone=reqs_per_addr:12m rate=10r/s;
+{% if not (sft_nginx_rate_limit_disabled | bool) -%}
+limit_req_zone "$binary_remote_addr$uri" zone=reqs_per_addr:12m rate={{ sft_nginx_rate_limit_requests_per_second }}r/s;
 limit_conn_zone "$binary_remote_addr$uri" zone=conns_per_addr:10m;
+{%- endif %}
 
 
 server {
@@ -41,8 +43,10 @@ server {
     limit_req_log_level error;
     limit_conn_log_level error;
 
-    limit_req zone=reqs_per_addr burst=20 nodelay;
-    limit_conn conns_per_addr 25;
+    {% if not (sft_nginx_rate_limit_disabled | bool) -%}
+    limit_req zone=reqs_per_addr burst={{ sft_nginx_rate_limit_burst_until }} nodelay;
+    limit_conn conns_per_addr {{ sft_nginx_rate_limit_max_connection_per_address }};
+    {%- endif %}
 
 
     location / {

--- a/roles/sft-server/templates/sftd.vhost.conf.j2
+++ b/roles/sft-server/templates/sftd.vhost.conf.j2
@@ -1,4 +1,4 @@
-{% if not (sft_nginx_rate_limit_disabled | bool) -%}
+{% if (sft_nginx_rate_limit_enabled | bool) -%}
 limit_req_zone "$binary_remote_addr$uri" zone=reqs_per_addr:12m rate={{ sft_nginx_rate_limit_requests_per_second }}r/s;
 limit_conn_zone "$binary_remote_addr$uri" zone=conns_per_addr:10m;
 {%- endif %}
@@ -43,7 +43,7 @@ server {
     limit_req_log_level error;
     limit_conn_log_level error;
 
-    {% if not (sft_nginx_rate_limit_disabled | bool) -%}
+    {% if (sft_nginx_rate_limit_enabled | bool) -%}
     limit_req zone=reqs_per_addr burst={{ sft_nginx_rate_limit_burst_until }} nodelay;
     limit_conn conns_per_addr {{ sft_nginx_rate_limit_max_connection_per_address }};
     {%- endif %}


### PR DESCRIPTION
This change is backward compatible (defaults to rate limit enabled). Though,
it introduces higher defaults.

Fixes https://github.com/zinfra/backend-issues/issues/1800