### PR TITLE
Respect `sft_nginx_sft_port` in -u argument

### DIFF
--- a/roles/sft-server/templates/sftd.service.j2
+++ b/roles/sft-server/templates/sftd.service.j2
@@ -39,7 +39,7 @@ ExecStart={{ sftd_bin_path }} \
             {% if sft_turn_discovery_enabled -%}
             -T \
             {% endif -%}
-            -u 'https://{{ sft_fqdn }}:443'
+            -u 'https://{{ sft_fqdn }}:{{ sft_nginx_sft_port }}'
 
 
 [Install]


### PR DESCRIPTION
As @lucendio  points out here https://github.com/wireapp/ansible-sft/issues/37 the port in `-u` should not be hardcoded
