### PR TITLE
Ensure services have started before testing them

### DIFF
--- a/roles/sft-server/tasks/main.yml
+++ b/roles/sft-server/tasks/main.yml
@@ -13,6 +13,9 @@
 - name: exposing service
   import_tasks: traffic.yml
 
+- name: ensure services have (re)started
+  meta: flush_handlers
+
 # NOTE: when staring a service managed by systemd its initial state is
 #       'active' and 'running' until the start timeout has passed, so
 #       the `is-active` test requires an initial delay. Typically the


### PR DESCRIPTION
# What's new in this PR?

### Issues

In certain cases Nginx may not have started after being installed. 

### Causes (Optional)

As a result, tasks in `test.yaml` would fail, as would the role as a consequence.

### Solutions

Force the handlers to run before the end of the play is reached and before `test.yaml` is imported.

### Testing

Tested against a development environment.
