### PR TITLE
[sft server] Introduce ufw feature flags

### DIFF
--- a/roles/sft-server/defaults/main.yml
+++ b/roles/sft-server/defaults/main.yml
@@ -94,3 +94,6 @@ sft_nginx_rate_limit_burst_until: "{{ 2 * (sft_nginx_rate_limit_requests_per_sec
 sft_nginx_rate_limit_max_connection_per_address: "{{ 3 * (sft_nginx_rate_limit_burst_until | int) }}"
 
 sft_metrics_enabled: true
+
+sft_firewall_enabled: true
+sft_firewall_ipv6_enabled: true

--- a/roles/sft-server/tasks/configure.yml
+++ b/roles/sft-server/tasks/configure.yml
@@ -168,3 +168,12 @@
     dest: "{{ sft_metrics_ca_path }}"
     mode: '400'
   when: sft_metrics_enabled
+
+
+- name: adjust IPv6 flag in ufw configuration if desired
+  replace:
+    path: '/etc/default/ufw'
+    regexp: '^(IPV6)=(.*)$'
+    replace: '\1={{ "yes" if sft_firewall_ipv6_enabled else "no" }}'
+  when:
+    - sft_firewall_enabled

--- a/roles/sft-server/tasks/install.yml
+++ b/roles/sft-server/tasks/install.yml
@@ -89,3 +89,4 @@
     state: present
     name:
       - ufw
+  when: sft_firewall_enabled

--- a/roles/sft-server/tasks/traffic.yml
+++ b/roles/sft-server/tasks/traffic.yml
@@ -4,6 +4,7 @@
     direction: incoming
     state: enabled
     logging: off
+  when: sft_firewall_enabled
 
 - name: allowing all egress
   ufw:
@@ -11,6 +12,7 @@
     direction: outgoing
     state: enabled
     logging: off
+  when: sft_firewall_enabled
 
 - name: allowing HTTP(S) ingress
   ufw:
@@ -22,6 +24,7 @@
     - '{{ sft_nginx_certbot_port }}'
     - '{{ sft_nginx_sft_port }}'
     - '{{ sft_nginx_metrics_port }}'
+  when: sft_firewall_enabled
 
 - name: allowing SSH ingress
   ufw:
@@ -30,6 +33,7 @@
     direction: in
     to_port: '22'
     state: reloaded
+  when: sft_firewall_enabled
 
 - name: allowing SFT media ingress
   ufw:
@@ -38,6 +42,7 @@
     direction: in
     to_port: "{{ sftd_udp_port_range_start }}:{{ sftd_udp_port_range_end }}"
     state: reloaded
+  when: sft_firewall_enabled
 
 - name: allowing SFT media egress
   ufw:
@@ -46,6 +51,7 @@
     direction: out
     from_port: "{{ sftd_udp_port_range_start }}:{{ sftd_udp_port_range_end }}"
     state: reloaded
+  when: sft_firewall_enabled
 
 - name: configuring SFT nginx vhost
   template:

--- a/roles/sft-server/tasks/traffic.yml
+++ b/roles/sft-server/tasks/traffic.yml
@@ -20,10 +20,12 @@
     proto: tcp
     to_port: "{{ item }}"
     state: reloaded
-  loop:
-    - '{{ sft_nginx_certbot_port }}'
-    - '{{ sft_nginx_sft_port }}'
-    - '{{ sft_nginx_metrics_port }}'
+  loop: >-
+    {{
+        [ sft_nginx_sft_port ]
+      + ([ sft_nginx_certbot_port ] if certbot_enabled else [])
+      + ([ sft_nginx_metrics_port ] if sft_metrics_enabled else [])
+    }}
   when: sft_firewall_enabled
 
 - name: allowing SSH ingress


### PR DESCRIPTION
# What's new in this PR?

### Issues

* missing option to disable firewall installation and setup
* missing option to disable or enable IPv6 in ufw

### Causes (Optional)

In a scenario with an external firewall, it might be desired to prevent a firewall from being installed on the same machine.

### Solutions

Introduce feature flag to conditionally not install and configure a firewall

### Testing

Applied to a test machine followed by a manual verification of the resulting state.

### Notes (Optional)

This change set also includes a small change that only allows ingress on ports which are actually being used.
