### PR TITLE
FS-444: Limit TLS ciphers to TR-02102-2 compatible ciphers

### DIFF
--- a/roles/sft-server/templates/metrics.vhost.conf.j2
+++ b/roles/sft-server/templates/metrics.vhost.conf.j2
@@ -8,7 +8,7 @@ server {
     access_log  off;
 
 
-    # NOTE: These are some sane defaults (compliant to TR-02102-2), you may want to overrride them on your own installation
+    # NOTE: These cipher suites are compliant to TR-02102-2. If you need to override them, please open a PR to introduce this functionality.
     # For TR-02102-2 see https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
     # As a Wire employee, for Wire-internal discussions and context see
     # * https://wearezeta.atlassian.net/browse/FS-33

--- a/roles/sft-server/templates/metrics.vhost.conf.j2
+++ b/roles/sft-server/templates/metrics.vhost.conf.j2
@@ -8,7 +8,11 @@ server {
     access_log  off;
 
 
-    # NOTE: intermediate configuration, still TBD!
+    # NOTE: These are some sane defaults (compliant to TR-02102-2), you may want to overrride them on your own installation
+    # For TR-02102-2 see https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
+    # As a Wire employee, for Wire-internal discussions and context see
+    # * https://wearezeta.atlassian.net/browse/FS-33
+    # * https://wearezeta.atlassian.net/browse/FS-444
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
 

--- a/roles/sft-server/templates/metrics.vhost.conf.j2
+++ b/roles/sft-server/templates/metrics.vhost.conf.j2
@@ -10,7 +10,7 @@ server {
 
     # NOTE: intermediate configuration, still TBD!
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
 
     ssl_certificate_key {% if certbot_enabled %}{{ certbot_live_path }}/{{ sft_fqdn }}/privkey.pem{% else %}{{ tls_key_path }}{% endif %};
     ssl_certificate {% if certbot_enabled %}{{ certbot_live_path }}/{{ sft_fqdn }}/fullchain.pem{% else %}{{ tls_cert_path }}{% endif %};

--- a/roles/sft-server/templates/sftd.vhost.conf.j2
+++ b/roles/sft-server/templates/sftd.vhost.conf.j2
@@ -14,7 +14,7 @@ server {
     access_log  off;
 
 
-    # NOTE: These are some sane defaults (compliant to TR-02102-2), you may want to overrride them on your own installation
+    # NOTE: These cipher suites are compliant to TR-02102-2. If you need to override them, please open a PR to introduce this functionality.
     # For TR-02102-2 see https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
     # As a Wire employee, for Wire-internal discussions and context see
     # * https://wearezeta.atlassian.net/browse/FS-33

--- a/roles/sft-server/templates/sftd.vhost.conf.j2
+++ b/roles/sft-server/templates/sftd.vhost.conf.j2
@@ -16,7 +16,7 @@ server {
 
     # NOTE: intermediate configuration, still TBD!
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
 
     ssl_certificate_key {% if certbot_enabled %}{{ certbot_live_path }}/{{ sft_fqdn }}/privkey.pem{% else %}{{ tls_key_path }}{% endif %};
     ssl_certificate {% if certbot_enabled %}{{ certbot_live_path }}/{{ sft_fqdn }}/fullchain.pem{% else %}{{ tls_cert_path }}{% endif %};

--- a/roles/sft-server/templates/sftd.vhost.conf.j2
+++ b/roles/sft-server/templates/sftd.vhost.conf.j2
@@ -14,7 +14,11 @@ server {
     access_log  off;
 
 
-    # NOTE: intermediate configuration, still TBD!
+    # NOTE: These are some sane defaults (compliant to TR-02102-2), you may want to overrride them on your own installation
+    # For TR-02102-2 see https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.html
+    # As a Wire employee, for Wire-internal discussions and context see
+    # * https://wearezeta.atlassian.net/browse/FS-33
+    # * https://wearezeta.atlassian.net/browse/FS-444
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
 


### PR DESCRIPTION
This aligns the ciphers with the current list on https://docs.wire.com/how-to/install/tls.html and disables the following ciphers:
* DHE-RSA-AES128-GCM-SHA256
* DHE-RSA-AES256-GCM-SHA384
* ECDHE-ECDSA-CHACHA20-POLY1305
* ECDHE-RSA-CHACHA20-POLY1305