### PR TITLE
Revert "add csp header for all the incoming origins (#48)"

### DIFF
--- a/roles/sft-server/templates/sftd.vhost.conf.j2
+++ b/roles/sft-server/templates/sftd.vhost.conf.j2
@@ -58,7 +58,6 @@ server {
 
         # TODO: should this be open to any third party?
         add_header Access-Control-Allow-Origin '*' always;
-        add_header Content-Security-Policy "default-src $http_origin";
 
         # NOTE: explicitly get rid of any cookie to prevent exposure to sftd
         proxy_set_header Cookie "";


### PR DESCRIPTION
This reverts commit 0839e76da61d1cb6e795bf412ea9ef60825e1370.

For implementing following things - https://wearezeta.atlassian.net/browse/WPB-4282 and https://wearezeta.atlassian.net/browse/WPB-5061

previously added a csp header in the sft side, but on recent testings, found out that we need to set the proper CORS on the SFT side and the CSP header needs to be added on the webapp side with the variable CSP_EXTRA_CONNECT_SRC

Hence, reverting the old commit.